### PR TITLE
Check for Blob instead of File

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ function isArray (value) {
   return Array.isArray(value)
 }
 
-function isFile (value) {
-  return value instanceof File
+function isBlob (value) {
+  return value instanceof Blob
 }
 
 function isDate (value) {
@@ -31,7 +31,7 @@ function objectToFormData (obj, fd, pre) {
 
       objectToFormData(value, fd, key)
     })
-  } else if (isObject(obj) && !isFile(obj) && !isDate(obj)) {
+  } else if (isObject(obj) && !isBlob(obj) && !isDate(obj)) {
     Object.keys(obj).forEach(function (prop) {
       var value = obj[prop]
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "standard": {
     "globals": [
       "FormData",
-      "File"
+      "File",
+      "Blob"
     ]
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,7 @@ global.FormData = class FormData {
   }
 }
 global.File = global.window.File
+global.Blob = global.window.Blob
 
 test('undefined', t => {
   const formData = objectToFormData({
@@ -121,6 +122,21 @@ test('File', t => {
     foo
   ])
   t.is(formData.get('foo'), foo)
+})
+
+test('Blob', t => {
+  const foo = new Blob([], {})
+  const formData = objectToFormData({
+    foo
+  })
+
+  t.true(formData.append.calledOnce)
+  t.deepEqual(formData.append.getCall(0).args, [
+    'foo',
+    foo
+  ])
+
+  t.true(formData.get('foo') instanceof File)
 })
 
 test('Date', t => {


### PR DESCRIPTION
The `File`  class extends `Blob`, so this is useful when you create a Blob yourself (from the stream api for example).

Note: When you append a `Blob` instance to `FormData` and call `FormData.get()` you'll get an instance of `File` instead of `Blob`.
That's why I added `t.true(formData.get('foo') instanceof File)` in the new test.