### PR TITLE
Duck-typing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# object-to-formdata
+  A convenient client-side JavaScript function to create a FormData instance from the key-value pairs of an Object instance.
+
+```
+const objectToFormData = require('object-to-formdata')
+
+
+const object = {
+  /**
+   * key-value pairs
+   * values can be primitives or objects
+   */
+}
+
+const formData = objectToFormData(object)
+
+console.log(formData)
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,49 @@
+'use strict'
+
+function isObject (value) {
+  return value === Object(value)
+}
+
+function isArray (value) {
+  return Array.isArray(value)
+}
+
+function isFile (value) {
+  return value instanceof File
+}
+
+function makeArrayKey (key) {
+  if (key.length > 2 && key.lastIndexOf('[]') === key.length - 2) {
+    return key
+  } else {
+    return key + '[]'
+  }
+}
+
+function objectToFormData (obj, fd, pre) {
+  fd = fd || new FormData()
+
+  Object.keys(obj).forEach(function (prop) {
+    var key = pre ? (pre + '[' + prop + ']') : prop
+
+    if (isObject(obj[prop]) && !isArray(obj[prop]) && !isFile(obj[prop])) {
+      objectToFormData(obj[prop], fd, key)
+    } else if (isArray(obj[prop])) {
+      obj[prop].forEach(function (value) {
+        var arrayKey = makeArrayKey(key)
+
+        if (isObject(value) && !isFile(value)) {
+          objectToFormData(value, fd, arrayKey)
+        } else {
+          fd.append(arrayKey, value)
+        }
+      })
+    } else {
+      fd.append(key, obj[prop])
+    }
+  })
+
+  return fd
+}
+
+module.exports = objectToFormData

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 'use strict'
 
+function isUndefined (value) {
+  return value === undefined
+}
+
 function isObject (value) {
   return value === Object(value)
 }
@@ -21,14 +25,9 @@ function isFile (value) {
       && typeof value.name === 'string'
 }
 
-function isUndefined (value) {
-  return value === undefined
-}
-
 function isDate (value) {
   return value instanceof Date
 }
-
 
 function objectToFormData (obj, fd, pre) {
   fd = fd || new FormData()

--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ function objectToFormData (obj, fd, pre) {
   Object.keys(obj).forEach(function (prop) {
     var key = pre ? (pre + '[' + prop + ']') : prop
 
+    if (obj[prop] === null || obj[prop] === undefined) return;
+
     if (isObject(obj[prop]) && !isArray(obj[prop]) && !isFile(obj[prop])) {
       objectToFormData(obj[prop], fd, key)
     } else if (isArray(obj[prop])) {

--- a/index.js
+++ b/index.js
@@ -8,8 +8,17 @@ function isArray (value) {
   return Array.isArray(value)
 }
 
+function isBlob (value) {
+  return value != null
+      && typeof value.size === 'number'
+      && typeof value.type === 'string'
+      && typeof value.slice === 'function'
+}
+
 function isFile (value) {
-  return value instanceof File
+  return isBlob(value)
+      && typeof value.lastModified === 'number'
+      && typeof value.name === 'string'
 }
 
 function isUndefined (value) {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ function isFile (value) {
   return value instanceof File
 }
 
+function isUndefined (value) {
+  return value === undefined
+}
+
 function makeArrayKey (key) {
   if (key.length > 2 && key.lastIndexOf('[]') === key.length - 2) {
     return key
@@ -26,7 +30,7 @@ function objectToFormData (obj, fd, pre) {
   Object.keys(obj).forEach(function (prop) {
     var key = pre ? (pre + '[' + prop + ']') : prop
 
-    if (obj[prop] === null || obj[prop] === undefined) return;
+    if (isUndefined(obj[prop])) return;
 
     if (isObject(obj[prop]) && !isArray(obj[prop]) && !isFile(obj[prop])) {
       objectToFormData(obj[prop], fd, key)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "object-to-formdata",
+  "version": "1.0.13",
+  "description": "A convenient client-side JavaScript function to create a FormData instance from the key-value pairs of an Object instance.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/therealparmesh/object-to-formdata.git"
+  },
+  "keywords": [
+    "object-to-formdata",
+    "javascript",
+    "object",
+    "formdata",
+    "form",
+    "submit"
+  ],
+  "author": "Parmesh Krishen",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/therealparmesh/object-to-formdata/issues"
+  },
+  "homepage": "https://github.com/therealparmesh/object-to-formdata#readme"
+}

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "formdata-polyfill": "^3.0.9",
-    "jsdom": "^11.6.1",
+    "jsdom": "^11.6.2",
     "nyc": "^11.4.1",
-    "sinon": "^4.2.2",
-    "standard": "^10.0.3"
+    "sinon": "^4.3.0",
+    "standard": "^11.0.0"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
This pull-request use duck-typing to check is an object is a `File`-like object since ReactNative don't have the concept of `File` or `Blob` objects (`Blob` objects will be supported on ReactNative 0.54, but not for older versions).

It also restore the commits history, do some minor clean-ups on docs and `package.json`, and update the project dependencies.