### PR TITLE
Revert "Refactoring types to allow import in TypeScript projects without allowSyntheticDefaultImports"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
-export declare function objectToFormData(
+export = objectToFormData;
+
+declare function objectToFormData(
   obj: any,
   cfg?: {
     indices?: boolean;


### PR DESCRIPTION
Reverts therealparmesh/object-to-formdata#74

Please see https://github.com/therealparmesh/object-to-formdata/issues/78
