### PR TITLE
Adding allowEmptyArrays option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ const options = {
    * defaults to false
    */
   booleansAsIntegers: false,
+
+  /**
+   * store arrays even if they're empty
+   * defaults to false
+   */
+  allowEmptyArrays: false,
 };
 
 const formData = objectToFormData(

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,10 @@ export const objectToFormData = (obj, cfg, fd, pre) => {
     ? false
     : cfg.booleansAsIntegers;
 
+  cfg.allowEmptyArrays = isUndefined(cfg.allowEmptyArrays)
+    ? false
+    : cfg.allowEmptyArrays;
+
   fd = fd || new FormData();
 
   if (isUndefined(obj)) {
@@ -56,6 +60,8 @@ export const objectToFormData = (obj, cfg, fd, pre) => {
 
         objectToFormData(value, cfg, fd, key);
       });
+    } else if (cfg.allowEmptyArrays) {
+      fd.append(pre + '[]', '');
     }
   } else if (isDate(obj)) {
     fd.append(pre, obj.toISOString());

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -241,6 +241,21 @@ test('Array with indices option', () => {
   expect(formData.get('foo[1]')).toBe('baz');
 });
 
+test('Array with allowEmptyArrays option', () => {
+  const formData = objectToFormData(
+    {
+      foo: [],
+    },
+    {
+      allowEmptyArrays: true,
+    },
+  );
+
+  expect(formData.append).toHaveBeenCalledTimes(1);
+  expect(formData.append).toHaveBeenNthCalledWith(1, 'foo[]', '');
+  expect(formData.get('foo[]')).toBe('');
+});
+
 test('Date', () => {
   const foo = new Date(2000, 0, 1, 1, 1, 1);
   const formData = objectToFormData({


### PR DESCRIPTION
Hello,

I'd like to add a small flag to allow for us to keep empty arrays in the outputted FormData.  I tried to follow your style, but if you feel the change isn't worthwhile or something needs changed please let me know.