### PR TITLE
added dot notation in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ const options = {
    * defaults to false
    */
   allowEmptyArrays: false,
+
+  /**
+   * Use the dot–notation for path expressions
+   * defaults to false
+   */
+  dotNotation: false,
 };
 
 const formData = serialize(

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,11 @@ const serialize = (obj, cfg, fd, pre) => {
         }
       }
 
-      const key = pre ? pre + '[' + prop + ']' : prop;
+      const key = pre
+        ? cfg.dotNotation
+          ? pre + '.' + prop
+          : pre + '[' + prop + ']'
+        : prop;
 
       serialize(value, cfg, fd, key);
     });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -277,3 +277,24 @@ test('File', () => {
   expect(formData.append).toHaveBeenCalledWith('foo', foo);
   expect(formData.get('foo')).toBe(foo);
 });
+
+test('DotNotation', () => {
+  const formData = serialize(
+    {
+      foo: {
+        bar: {
+          baz: {
+            qux: 'quux',
+          },
+        },
+      },
+    },
+    {
+      dotNotation: true,
+    },
+  );
+
+  expect(formData.append).toHaveBeenCalledTimes(1);
+  expect(formData.append).toHaveBeenCalledWith('foo.bar.baz.qux', 'quux');
+  expect(formData.get('foo.bar.baz.qux')).toBe('quux');
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -3,6 +3,7 @@ export type Options = {
   nullsAsUndefineds?: boolean;
   booleansAsIntegers?: boolean;
   allowEmptyArrays?: boolean;
+  dotNotation?: boolean;
 };
 
 export const serialize: <T = {}>(


### PR DESCRIPTION
I added the dot notation in the config, because I noticed that the mapping of a nested object of type IFormFile in C # was always null and with the dot notation the deserialization works and my object contains the correct value.